### PR TITLE
added image file support

### DIFF
--- a/bootstrap_carousel/streamlit_carousel/__init__.py
+++ b/bootstrap_carousel/streamlit_carousel/__init__.py
@@ -1,11 +1,11 @@
 import os
+import base64
 from typing import TypedDict, List
 
 import streamlit as st
 import streamlit.components.v1 as components
 
 # TODO:
-#  - enable image files
 #  - fix overflow issue when item's text is too long
 
 _RELEASE = True
@@ -33,6 +33,13 @@ class Item(TypedDict):
     link: str
 
 
+def get_image_data_url(file_path: str) -> str:
+    """Convert a local image file to a data URL."""
+    with open(file_path, "rb") as image_file:
+        encoded_string = base64.b64encode(image_file.read()).decode()
+    return f"data:image/png;base64,{encoded_string}"
+
+
 def validate_items(items: List[Item]) -> List[Item]:
     for item in items:
         if "img" not in item:
@@ -51,6 +58,8 @@ def validate_items(items: List[Item]) -> List[Item]:
             item["interval"] = None
         if "link" not in item:
             item["link"] = None
+        if os.path.isfile(item["img"]):
+            item["img"] = get_image_data_url(item["img"])
     return items
 
 


### PR DESCRIPTION
Hey,

added support for local files in your carousel. 

Below I added a few screens showing a minimal working example for the app.

Feel free to add this, or request some changes, but I can't guarantee I'll have time to implement anything too extensive :)

<img width="920" alt="Screenshot 2024-06-27 at 18 04 43" src="https://github.com/thomasbs17/streamlit-contributions/assets/7212724/c5eb2a32-3cf4-49c9-ab0a-af5f3044c0b6">
<img width="674" alt="Screenshot 2024-06-27 at 18 04 55" src="https://github.com/thomasbs17/streamlit-contributions/assets/7212724/711b5a7c-092a-4c7b-a3fc-1d9e48b80caf">
<img width="630" alt="Screenshot 2024-06-27 at 18 05 06" src="https://github.com/thomasbs17/streamlit-contributions/assets/7212724/33e817e8-54af-4495-9683-7be51bcf0071">

<img width="604" alt="Screenshot 2024-06-27 at 18 05 01" src="https://github.com/thomasbs17/streamlit-contributions/assets/7212724/156cd3e2-b1e0-4a03-b3da-069dfad070ba">
<img width="1204" alt="Screenshot 2024-06-27 at 18 05 40" src="https://github.com/thomasbs17/streamlit-contributions/assets/7212724/2b7dd05b-f830-4b59-9c59-6ec2f8ce43f7">



